### PR TITLE
Check whether tests are run on the development version

### DIFF
--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -8,6 +8,8 @@
 # * remove the "Upload to GitHub release" step
 # * remove the emscripten / pytest step -- this fails for reasons that are too
 #   hard to to debug right now
+# * added --no-index to local package installation as
+#   workaround for https://github.com/PyO3/maturin/issues/1971
 #
 name: CI
 
@@ -64,7 +66,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          pip install cbor-diag --find-links dist --force-reinstall
+          pip install cbor-diag --no-index --find-links dist --force-reinstall
           pip install pytest
           pytest
       - name: pytest
@@ -80,7 +82,7 @@ jobs:
             pip3 install -U pip pytest
           run: |
             set -e
-            pip3 install cbor-diag --find-links dist --force-reinstall
+            pip3 install cbor-diag --no-index --find-links dist --force-reinstall
             pytest
 
   windows:
@@ -114,7 +116,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          pip install cbor-diag --find-links dist --force-reinstall
+          pip install cbor-diag --no-index --find-links dist --force-reinstall
           pip install pytest
           pytest
 
@@ -148,7 +150,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          pip install cbor-diag --find-links dist --force-reinstall
+          pip install cbor-diag --no-index --find-links dist --force-reinstall
           pip install pytest
           pytest
 

--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -66,6 +66,7 @@ jobs:
         shell: bash
         run: |
           set -e
+          pwd; ls -la; ls -la ./dist/
           pip install cbor-diag --no-index --find-links dist --force-reinstall
           pip install pytest
           pytest
@@ -82,6 +83,7 @@ jobs:
             pip3 install -U pip pytest
           run: |
             set -e
+            pwd; ls -la; ls -la ./dist/
             pip3 install cbor-diag --no-index --find-links dist --force-reinstall
             pytest
 
@@ -116,6 +118,7 @@ jobs:
         shell: bash
         run: |
           set -e
+          pwd; ls -la; ls -la ./dist/
           pip install cbor-diag --no-index --find-links dist --force-reinstall
           pip install pytest
           pytest
@@ -150,6 +153,7 @@ jobs:
         shell: bash
         run: |
           set -e
+          pwd; ls -la; ls -la ./dist/
           pip install cbor-diag --no-index --find-links dist --force-reinstall
           pip install pytest
           pytest

--- a/doctest.txt
+++ b/doctest.txt
@@ -13,3 +13,5 @@ src/lib.rs. They are manually extracted until I've figured out why `pytest
 >>> encoded = bytes.fromhex('a1016568656c6c6f')
 >>> cbor2diag(encoded)
 '{1: "hello"}'
+>>> cbor2diag(encoded, dummy=True)
+'{1: "hello"}'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,9 @@ fn diag2cbor(py: Python<'_>, diagnostic: &str) -> PyResult<PyObject> {
 /// Key word arguments influence additional details:
 ///
 /// * With ``pretty=False``, no space is left after colons, commas etc.
-#[pyfunction(signature = (encoded, *, pretty=true))]
-fn cbor2diag(_py: Python<'_>, encoded: &[u8], pretty: bool) -> PyResult<String> {
+#[pyfunction(signature = (encoded, *, pretty=true, dummy=false))]
+fn cbor2diag(_py: Python<'_>, encoded: &[u8], pretty: bool, dummy: bool) -> PyResult<String> {
+    let _ = dummy;
     let parsed = cbor_diag_rs::parse_bytes(encoded)
         .map_err(|e| match e {
             cbor_diag_rs::Error::Todo(s) => pyo3::exceptions::PyValueError::new_err(s),


### PR DESCRIPTION
As CI fails in #3 , let's quickly verify that tests are indeed run on the new version and not on what gets installed from pip.