### PR TITLE
Add support for tag 999

### DIFF
--- a/doctest.txt
+++ b/doctest.txt
@@ -10,6 +10,9 @@ src/lib.rs. They are manually extracted until I've figured out why `pytest
 >>> import cbor2                # doctest: +SKIP
 >>> cbor2.loads(encoded)        # doctest: +SKIP
 {1: 'hello'}
+>>> cbor2.loads(diag2cbor("[1, spam'eggs']", to999=True))     # doctest: +SKIP
+[1, CBORTag(999, ['spam', 'eggs'])]
+>>> from cbor_diag import *
 >>> encoded = bytes.fromhex('a1016568656c6c6f')
 >>> cbor2diag(encoded)
 '{1: "hello"}'
@@ -18,3 +21,5 @@ src/lib.rs. They are manually extracted until I've figured out why `pytest
 "DT'1970-01-01T00:00:05+00:00'"
 >>> cbor2diag(encoded, pretty=False)
 '1(5)'
+>>> cbor2diag(bytes.fromhex("d9 03e7 82 63 666f6f 63 626172"), from999=True)
+"foo'bar'"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,12 +56,59 @@ fn diag2cbor(py: Python<'_>, diagnostic: &str, to999: bool) -> PyResult<PyObject
 ///
 /// >>> cbor2diag(encoded, pretty=False)
 /// '1(5)'
-#[pyfunction(signature = (encoded, *, pretty=true))]
-fn cbor2diag(_py: Python<'_>, encoded: &[u8], pretty: bool) -> PyResult<String> {
+///
+/// * With ``from999=True`, CBOR tag 999 will be rendered as application oriented literal. Unlike
+///   other tags, this does not happen by default, as that tag is not intended to be used that way
+///   by default.
+///
+/// >>> cbor2diag(bytes.fromhex("d9 03e7 82 63 666f6f 63 626172"), from999=True)
+/// "foo'bar'"
+#[pyfunction(signature = (encoded, *, pretty=true, from999=false))]
+fn cbor2diag(_py: Python<'_>, encoded: &[u8], pretty: bool, from999: bool) -> PyResult<String> {
     let mut parsed = cbor_edn::StandaloneItem::from_cbor(encoded)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{}", e)))?;
     if pretty {
         parsed.visit_tag(&mut cbor_edn::application::all_tag_prettify);
+        parsed.visit_tag(&mut |tag, item: &mut cbor_edn::Item| {
+            if tag != 999 {
+                return Ok(());
+            }
+            let tagged = item.get_tagged().expect("Visitor promises this is true");
+            // This is the most absurd effect of <https://codeberg.org/chrysn/cbor-edn/issues/16>:
+            // We have to serialize the item, turn it into a sequence, and use that
+            let tagged_serialized = tagged.serialize();
+            let mut tagged_as_seq = cbor_edn::Sequence::parse(&tagged_serialized).unwrap();
+            let tagged_again = tagged_as_seq.get_items_mut().next().unwrap();
+            let Ok(mut items) = tagged_again.get_array_items() else {
+                return Err("should be array".into());
+            };
+            let Some(ident) = items.next() else {
+                return Err("should contain 2 items".into());
+            };
+            let Some(value) = items.next() else {
+                return Err("should contain 2 items".into());
+            };
+            let None = items.next() else {
+                return Err("should contain 2 items".into());
+            };
+            // This is crude for lack of <https://codeberg.org/chrysn/cbor-edn/issues/16>, but
+            // shows how to work around missing parts
+            let ident = ident.serialize();
+            let value = value.serialize();
+            if !ident.starts_with('"') || !value.starts_with('"') {
+                return Err("should be strings".into());
+            }
+            let constructed = format!("{}'{}'", ident.trim_matches('"'), value.trim_matches('"'));
+            drop(items);
+            let mut constructed = cbor_edn::Sequence::parse(&constructed)
+                .map_err(|_| "Might contain escapes that can't be processed yet")?;
+            let constructed = constructed.get_items_mut().next().unwrap();
+            // Can't use constructed yet because of
+            // <https://codeberg.org/chrysn/cbor-edn/issues/17>
+            let (ident, value) = constructed.get_application_literal().expect("Was parsed successfully from something roughly app literal shaped");
+            *item = cbor_edn::Item::new_application_literal(&ident, &value).expect("Was just produced by parsing");
+            Ok(())
+        });
         parsed.set_delimiters(cbor_edn::DelimiterPolicy::indented());
         Ok(parsed.serialize())
     } else {


### PR DESCRIPTION
This is optional everywhere as intended by 999; the implementation is crude, but doing something outside the original crate to test the APIs.

This enables high-level applications to work with experimental application-oriented literals, possibly with the added context they have.