### PR TITLE
pyproject: Pull available metadata from Cargo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,14 @@ dynamic = [
     "license",
     "readme",
     "requires-python",
-    "urls",
+    # "urls", disabled, see project.urls
     "version",
 ]
+
+[project.urls]
+# Workaround for <https://github.com/PyO3/maturin/pull/2760>
+Documentation = "https://cbor-diag.readthedocs.io"
+"Source Code" = "https://github.com/chrysn/cbor-diag-py"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,21 @@ build-backend = "maturin"
 
 [project]
 name = "cbor-diag"
-requires-python = ">=3.7"
 classifiers = [
     "Development Status :: 6 - Mature",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Rust",
 ]
-dynamic = ["version"]
+dynamic = [
+    "description",
+    "license",
+    "readme",
+    "requires-python",
+    "urls",
+    "version",
+]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]


### PR DESCRIPTION
The Trove license classifiers are obsolete now that SPDX based explicit metadata is available.

Closes: https://github.com/chrysn/cbor-diag-py/issues/16