### PR TITLE
Update version to 1.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cbor-diag-python-package"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "cbor-edn",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbor-diag-python-package"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Conversion between CBOR and CBOR Diagnostic Notation"


### PR DESCRIPTION
Changes:

* Add type stubs using pyo3-stub-gen
* Drop support for Python 3.9
* Extend documentation on cbor2 interaction and stability
* Update build dependencies (Maturin, PyO3)
* Minor refacteoring