### PR TITLE
Extend testing

### DIFF
--- a/tests/test_ellipsis.py
+++ b/tests/test_ellipsis.py
@@ -1,0 +1,19 @@
+from cbor_diag import *
+
+def test_ellipsis():
+    diagnostic = '[1, 2, ..., 99]'
+    try:
+        encoded = diag2cbor(diagnostic)
+    except ValueError:
+        pass
+    else:
+        raise RuntimeError("Expected error, received encoded {encoded.hex()}")
+
+def test_inline_ellipsis():
+    diagnostic = "h'00 11 .. ff'"
+    try:
+        encoded = diag2cbor(diagnostic)
+    except ValueError:
+        pass
+    else:
+        raise RuntimeError("Expected error, received encoded {encoded.hex()}")

--- a/tests/test_from999.py
+++ b/tests/test_from999.py
@@ -26,4 +26,4 @@ def test_failing():
         encoded = cbor2.dumps(item)
         edn = cbor2diag(encoded, from999=True)
         # It emits some comment, we don't check for which precisely.
-        assert edn.startswith(cbor2diag(encoded) + '/ '), f"Itemm was expected to just ignore from999, but produced {edn}: {item}"
+        assert edn.startswith(cbor2diag(encoded) + '/ '), f"Item {item!r} was expected to leave the broken tag 999 and show an error inline, but produced {edn!r}"


### PR DESCRIPTION
The test also uncovered https://codeberg.org/chrysn/cbor-edn/pulls/35.