### PR TITLE
Keep a change log

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,67 @@
+# Changelog
+
+## Unreleased
+
+* Add support for CBOR sequences using `seq=True` argument
+* Update cbor-edn dependency (no changes in behavior)
+* Extend test coverage
+
+## 1.1.3
+
+* Add type stubs using pyo3-stub-gen
+* Drop support for Python 3.9
+* Extend documentation on cbor2 interaction and stability
+* Update build dependencies (Maturin, PyO3)
+* Minor refacteoring
+
+## 1.1.2
+
+* Package metadata is exported through maturin, populating PyPI presentation
+
+## 1.1.1
+
+* Editorial changes to documentation.
+* Dependencies updated.
+* Simplified code based on cbor-edn 0.0.8 enhancements.
+
+## 1.1.0
+
+* The backend is switched from cbor-diag to cbor-edn.
+
+  This enables processing of diagnostic data in the latest draft
+  version, and application oriented literals (eg. ip'2001:db8::/64').
+  This change also simplifies the output, because encoding indicators
+  are now only emitted where necessary for round-tripping.
+
+* The conversion methods have arguments `from999` and `to999`, enabling
+  applications to do their own processing of application-oriented
+  literals.
+
+* Maturin and PyO3 are updated.
+
+
+## 1.0.3
+
+* PyO3 updated to 0.22, therefore supporting Python 3.13
+* CI fixes
+
+
+## 1.0.2
+
+* Maturin updated to version 1.5
+* Updates to Cargo.lock
+
+  This restores building when Cargo.lock is observed on the latest
+  nightly versions due to proc-macro2's opportunistic use of nightly
+  features.
+
+
+## 1.0.1
+
+* Documentation updates
+* Updates to Cargo.lock
+
+  While this would usually not be a relevant change in a library crate,
+  this being a Python package to which ther Cargo.lock is input makes it
+  relevant, especially as the updated cargo-diag crate pulls in a newer
+  version of nom that does not use accidental features of rustc.

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,12 +1,15 @@
-# Changelog
+Changelog
+=========
 
-## Unreleased
+Unreleased
+----------
 
 * Add support for CBOR sequences using `seq=True` argument
 * Update cbor-edn dependency (no changes in behavior)
 * Extend test coverage
 
-## 1.1.3
+1.1.3
+-----
 
 * Add type stubs using pyo3-stub-gen
 * Drop support for Python 3.9
@@ -14,17 +17,20 @@
 * Update build dependencies (Maturin, PyO3)
 * Minor refacteoring
 
-## 1.1.2
+1.1.2
+-----
 
 * Package metadata is exported through maturin, populating PyPI presentation
 
-## 1.1.1
+1.1.1
+-----
 
 * Editorial changes to documentation.
 * Dependencies updated.
 * Simplified code based on cbor-edn 0.0.8 enhancements.
 
-## 1.1.0
+1.1.0
+-----
 
 * The backend is switched from cbor-diag to cbor-edn.
 
@@ -40,13 +46,15 @@
 * Maturin and PyO3 are updated.
 
 
-## 1.0.3
+1.0.3
+-----
 
 * PyO3 updated to 0.22, therefore supporting Python 3.13
 * CI fixes
 
 
-## 1.0.2
+1.0.2
+-----
 
 * Maturin updated to version 1.5
 * Updates to Cargo.lock
@@ -56,7 +64,8 @@
   features.
 
 
-## 1.0.1
+1.0.1
+-----
 
 * Documentation updates
 * Updates to Cargo.lock

--- a/doc/NEWS.rst
+++ b/doc/NEWS.rst
@@ -1,0 +1,1 @@
+.. include:: ../NEWS.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,6 +2,12 @@
 cbor-diag: Diagnostic notation for CBOR
 =======================================
 
+.. toctree::
+   :hidden:
+
+   API documentation <self>
+   NEWS.rst
+
 See the project README_ file for installation, maintenance and license information.
 
 .. _README: https://github.com/chrysn/cbor-diag-py/blob/main/README.rst


### PR DESCRIPTION
Previously, change logs were kept in the commit messages that bumped the version.

This makes things more visible in the checkout, and includes them in the docs as well.