### PR TITLE
doc: Cosmetic fixes

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -5,12 +5,12 @@ Changelog
 -----
 
 * Update build system dependencies (Maturin)
-* Publish wheels for ``pyemscripten_2026_`` (pyodide 314 / PEP 783)
+* Publish wheels for ``pyemscripten_2026_0`` (pyodide 314 / PEP 783)
 
 1.1.4
 -----
 
-* Add support for CBOR sequences using `seq=True` argument
+* Add support for CBOR sequences using ``seq=True`` argument
 * Update cbor-edn dependency (no changes in behavior)
 * Extend test coverage
 
@@ -45,7 +45,7 @@ Changelog
   This change also simplifies the output, because encoding indicators
   are now only emitted where necessary for round-tripping.
 
-* The conversion methods have arguments `from999` and `to999`, enabling
+* The conversion methods have arguments ``from999`` and ``to999``, enabling
   applications to do their own processing of application-oriented
   literals.
 
@@ -77,6 +77,6 @@ Changelog
 * Updates to Cargo.lock
 
   While this would usually not be a relevant change in a library crate,
-  this being a Python package to which ther Cargo.lock is input makes it
+  this being a Python package to which the Cargo.lock is input makes it
   relevant, especially as the updated cargo-diag crate pulls in a newer
   version of nom that does not use accidental features of rustc.

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ cbor-diag: Diagnostic notation (EDN) for CBOR
 =============================================
 
 This Python module is a minimal wrapper around the `cbor-edn crate`_
-(formally around the `cbor-diag crate`_).
+(formerly around the `cbor-diag crate`_).
 Unlike those crates,
 which offers lots of functionality for manipulating CBOR and its diagnostic notation,
 this module only exposes two very simple functions:

--- a/python/cbor_diag/__init__.pyi
+++ b/python/cbor_diag/__init__.pyi
@@ -32,14 +32,15 @@ def cbor2diag(encoded: bytes, *, pretty: builtins.bool = ..., from999: builtins.
     >>> cbor2diag(cbor2.dumps([1, 2]), pretty=False)
     '[1,2]'
     
-    * With `seq=True`, [CBOR sequences](https://datatracker.ietf.org/doc/html/rfc8742)
-      are tolerated:
+    * With `seq=True`, `CBOR sequences`_ are tolerated:
     
     >>> print(cbor2diag('\x01\x02\x03', seq=True))
     1,
     2,
     3
     <BLANKLINE>
+    
+    .. _`CBOR sequences`: https://datatracker.ietf.org/doc/html/rfc8742
     
     * With ``from999=True``, CBOR tag 999 will be rendered as application oriented literal. Unlike
       other tags, this does not happen by default, as that tag is not intended to be used that way
@@ -70,10 +71,12 @@ def diag2cbor(diagnostic: builtins.str, *, to999: builtins.bool = ..., seq: buil
     >>> cbor2.loads(diag2cbor("[1, spam'eggs']", to999=True))
     [1, CBORTag(999, ['spam', 'eggs'])]
     
-    * With `seq=True`, [CBOR sequences](https://datatracker.ietf.org/doc/html/rfc8742)
+    * With ``seq=True``, `CBOR sequences`_
       are tolerated:
     
     >>> diag2cbor("1, 2, 3", seq=True)
     '\x01\x02\x03'
+    
+    .. _`CBOR sequences`: https://datatracker.ietf.org/doc/html/rfc8742
     """
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,11 +21,13 @@ use pyo3_stub_gen::{define_stub_info_gatherer, derive::gen_stub_pyfunction};
 /// >>> cbor2.loads(diag2cbor("[1, spam'eggs']", to999=True))
 /// [1, CBORTag(999, ['spam', 'eggs'])]
 ///
-/// * With `seq=True`, [CBOR sequences](https://datatracker.ietf.org/doc/html/rfc8742)
+/// * With ``seq=True``, `CBOR sequences`_
 ///   are tolerated:
 ///
 /// >>> diag2cbor("1, 2, 3", seq=True)
 /// '\x01\x02\x03'
+///
+/// .. _`CBOR sequences`: https://datatracker.ietf.org/doc/html/rfc8742
 #[gen_stub_pyfunction]
 #[pyfunction(signature = (diagnostic, *, to999=false, seq=false))]
 fn diag2cbor(py: Python<'_>, diagnostic: &str, to999: bool, seq: bool) -> PyResult<Py<PyBytes>> {
@@ -68,14 +70,15 @@ fn diag2cbor(py: Python<'_>, diagnostic: &str, to999: bool, seq: bool) -> PyResu
 /// >>> cbor2diag(cbor2.dumps([1, 2]), pretty=False)
 /// '[1,2]'
 ///
-/// * With `seq=True`, [CBOR sequences](https://datatracker.ietf.org/doc/html/rfc8742)
-///   are tolerated:
+/// * With `seq=True`, `CBOR sequences`_ are tolerated:
 ///
 /// >>> print(cbor2diag('\x01\x02\x03', seq=True))
 /// 1,
 /// 2,
 /// 3
 /// <BLANKLINE>
+///
+/// .. _`CBOR sequences`: https://datatracker.ietf.org/doc/html/rfc8742
 ///
 /// * With ``from999=True``, CBOR tag 999 will be rendered as application oriented literal. Unlike
 ///   other tags, this does not happen by default, as that tag is not intended to be used that way


### PR DESCRIPTION
Mostly markdown-isms that sneaked into ReST Python documentation.